### PR TITLE
Fix rfc3339.t test to succeed if timezone is not CET.

### DIFF
--- a/t/rfc3339.t
+++ b/t/rfc3339.t
@@ -1,10 +1,13 @@
 use Test;
+use POSIX;
 use lib "lib";
 BEGIN { plan tests => 41 };
 use Parse::Syslog;
 ok(1); # If we made it this far, we're ok.
 
 #########################
+$ENV{TZ} = 'CET-1CEST-2,M3.5.0/02:00:00,M10.5.0/03:00:00';
+POSIX::tzset();
 
 my $parser = Parse::Syslog->new("t/linux-rfc3339syslog");
 open(PARSED, "<t/linux-parsed") or die "can't open t/linux-parsed: $!\n";


### PR DESCRIPTION
At the bottom of https://rt.cpan.org/Public/Bug/Display.html?id=63897 I mentioned, that the t/rfc3339.t test fails if current timezone is not CET.
So I merged the timezone fix from t/dst.t to t/rfc3339.t.